### PR TITLE
Change how current role is tracked

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.ba.call.highlight'
-version = '1.0'
+version = '1.1-SNAPSHOT'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.9.15.2'
+def runeLiteVersion = '1.10.5'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.ba.call.highlight'
-version = '1.1-SNAPSHOT'
+version = '1.1'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/ba/call/highlight/baCallHighlightPlugin.java
+++ b/src/main/java/com/ba/call/highlight/baCallHighlightPlugin.java
@@ -6,8 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.MenuEntry;
 import net.runelite.api.events.ClientTick;
-import net.runelite.api.events.GameStateChanged;
-import net.runelite.api.events.MenuEntryAdded;
+import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
@@ -31,6 +30,9 @@ public class baCallHighlightPlugin extends Plugin
 	@Inject private baCallHighlightConfig config;
 
 	private final Map<String, String> callToMenuEntry = new HashMap<>();
+
+	private Role role;
+
 	private enum Role
 	{
 		COLLECTOR(486, 9),
@@ -73,22 +75,51 @@ public class baCallHighlightPlugin extends Plugin
 	}
 
 	@Subscribe
+	public void onWidgetLoaded(WidgetLoaded event)
+	{
+		final int groupId = event.getGroupId();
+
+		if (groupId == Role.COLLECTOR.groupID)
+		{
+			role = Role.COLLECTOR;
+		}
+		else if (groupId == Role.HEALER.groupID)
+		{
+			role = Role.HEALER;
+		}
+		else if (groupId == Role.ATTACKER.groupID)
+		{
+			role = Role.ATTACKER;
+		}
+		else if (groupId == Role.DEFENDER.groupID)
+		{
+			role = Role.DEFENDER;
+		}
+	}
+
+	@Subscribe
 	public void onClientTick(ClientTick clientTick)
 	{
-		MenuEntry[] entries = client.getMenuEntries();
-		for(Role role : Role.values())
+		if (role == null)
 		{
-			Widget activeWidget = client.getWidget(role.groupID, role.childID);
-			if(activeWidget != null)
+			return;
+		}
+
+		Widget activeWidget = client.getWidget(role.groupID, role.childID);
+		if (activeWidget == null)
+		{
+			return;
+		}
+
+		for (MenuEntry entry : client.getMenuEntries())
+		{
+			if (Text.removeTags(entry.getOption()).equals(callToMenuEntry.get(activeWidget.getText())))
 			{
-				for(MenuEntry entry : entries) {
-					if(Text.removeTags(entry.getOption()).equals(callToMenuEntry.get(activeWidget.getText()))) {
-						entry.setOption(ColorUtil.prependColorTag(Text.removeTags(entry.getOption()), config.highlightCallColor()));
-					} else {
-						entry.setOption(Text.removeTags(entry.getOption()));
-					}
-				}
-				return;
+				entry.setOption(ColorUtil.prependColorTag(Text.removeTags(entry.getOption()), config.highlightCallColor()));
+			}
+			else
+			{
+				entry.setOption(Text.removeTags(entry.getOption()));
 			}
 		}
 	}


### PR DESCRIPTION
I've noticed two bugs while using this plugin:

1. Sometimes completely fails to highlight current call.
2. Sometimes gets stuck on the same highlight, despite the current call.

Once the plugin gets into one of these broken states, the only fix seems to be restarting the client. I haven't found a consistent way to reproduce these bugs, but they both seem to happen after finishing a round and/or changing roles.

My best guess is that the current implementation for getting the player's role doesn't always work (`Client#getWidget` possibly returns non-null even if the widget no longer "exists"), so I changed the way the player's role is tracked to mimic the ba-minigame hub plugin.